### PR TITLE
CORE-2992: Add npmrc security defaults#2

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 save-exact=true
+ignore-scripts=true
+min-release-age=7


### PR DESCRIPTION
As per the https://defra.github.io/software-development-standards/standards/node_standards